### PR TITLE
Correct linking error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ clean:
 	@rm $(BIN)
 
 build: main.cpp
-	$(CC) -o $(BIN) $(CCFLAGS) $(LDFLAGS) $<
+	$(CC) -o $(BIN) $(CCFLAGS) $< $(LDFLAGS)
 
 install:
 	install -m 775 $(BIN) $(DESTDIR)$(PREFIX)/bin


### PR DESCRIPTION
Correct a linking error on an Ubuntu 20.04.5 system by moving the position of the source file to before the LDFLAGS variable.

When linking libraries should be specified after the object files so the single pass linking succeeds. Otherwise, the build will fail linking with unresolved symbols.